### PR TITLE
Fixes #34 #35 fix ssltls hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Added support for all possible parameters for both AAM Credential Provider (CLIP
 ## Table of Contents <!-- OMIT IN TOC -->
 
 - [pyAIM](#pyaim)
-    - [New in Version 1.2.0: <!-- OMIT IN TOC -->](#new-in-version-120)
-  - [Table of Contents <!-- OMIT IN TOC -->](#table-of-contents)
+    - [New in Version 1.2.0:](#new-in-version-120)
+  - [Table of Contents](#table-of-contents)
   - [Install](#install)
     - [Pre-Requisite](#pre-requisite)
       - [Credential Provider (CLIPasswordSDK) Method](#credential-provider-clipasswordsdk-method)
@@ -54,6 +54,9 @@ Added support for all possible parameters for both AAM Credential Provider (CLIP
 ## Install
 
 ### Pre-Requisite
+
+* Add `,` to the `PasswordForbiddenChars` of the platform of accounts to be retrieved using this module.
+  * `,` is used as a delimiter between data returned in the response.
 
 #### Credential Provider (CLIPasswordSDK) Method
 

--- a/pyaim/aimccp.py
+++ b/pyaim/aimccp.py
@@ -17,6 +17,7 @@ class CCPPasswordREST(object):
 
         if verify is False:
             self._context = ssl._create_unverified_context()
+            self._context.check_hostname = True
 
 
     # Checks that the AIM Web Service is available

--- a/pyaim/version.py
+++ b/pyaim/version.py
@@ -6,4 +6,4 @@ This module contains the version information about the project that
 is intended to be reused in multiple places.
 """
 
-__version__ = '1.2.9'
+__version__ = '1.3.0'


### PR DESCRIPTION
Fix #34:
* Updated README to include pre-requesite of `,` in `PasswordForbiddenChars` of platforms being used.

Fix #35:
* Add hostname verification despite not verifying certificate signature for self-signed certificates.