### PR TITLE
Add Client Certificate support for CCPPasswordREST

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -204,24 +204,24 @@
         },
         "nh3": {
             "hashes": [
-                "sha256:116c9515937f94f0057ef50ebcbcc10600860065953ba56f14473ff706371873",
-                "sha256:18415df36db9b001f71a42a3a5395db79cf23d556996090d293764436e98e8ad",
-                "sha256:203cac86e313cf6486704d0ec620a992c8bc164c86d3a4fd3d761dd552d839b5",
-                "sha256:2b0be5c792bd43d0abef8ca39dd8acb3c0611052ce466d0401d51ea0d9aa7525",
-                "sha256:377aaf6a9e7c63962f367158d808c6a1344e2b4f83d071c43fbd631b75c4f0b2",
-                "sha256:525846c56c2bcd376f5eaee76063ebf33cf1e620c1498b2a40107f60cfc6054e",
-                "sha256:5529a3bf99402c34056576d80ae5547123f1078da76aa99e8ed79e44fa67282d",
-                "sha256:7771d43222b639a4cd9e341f870cee336b9d886de1ad9bec8dddab22fe1de450",
-                "sha256:88c753efbcdfc2644a5012938c6b9753f1c64a5723a67f0301ca43e7b85dcf0e",
-                "sha256:93a943cfd3e33bd03f77b97baa11990148687877b74193bf777956b67054dcc6",
-                "sha256:9be2f68fb9a40d8440cbf34cbf40758aa7f6093160bfc7fb018cce8e424f0c3a",
-                "sha256:a0c509894fd4dccdff557068e5074999ae3b75f4c5a2d6fb5415e782e25679c4",
-                "sha256:ac8056e937f264995a82bf0053ca898a1cb1c9efc7cd68fa07fe0060734df7e4",
-                "sha256:aed56a86daa43966dd790ba86d4b810b219f75b4bb737461b6886ce2bde38fd6",
-                "sha256:e8986f1dd3221d1e741fda0a12eaa4a273f1d80a35e31a1ffe579e7c621d069e",
-                "sha256:f99212a81c62b5f22f9e7c3e347aa00491114a5647e1f13bbebd79c3e5f08d75"
+                "sha256:0d02d0ff79dfd8208ed25a39c12cbda092388fff7f1662466e27d97ad011b770",
+                "sha256:3277481293b868b2715907310c7be0f1b9d10491d5adf9fce11756a97e97eddf",
+                "sha256:3b803a5875e7234907f7d64777dfde2b93db992376f3d6d7af7f3bc347deb305",
+                "sha256:427fecbb1031db085eaac9931362adf4a796428ef0163070c484b5a768e71601",
+                "sha256:5f0d77272ce6d34db6c87b4f894f037d55183d9518f948bba236fe81e2bb4e28",
+                "sha256:60684857cfa8fdbb74daa867e5cad3f0c9789415aba660614fe16cd66cbb9ec7",
+                "sha256:6f42f99f0cf6312e470b6c09e04da31f9abaadcd3eb591d7d1a88ea931dca7f3",
+                "sha256:86e447a63ca0b16318deb62498db4f76fc60699ce0a1231262880b38b6cff911",
+                "sha256:8d595df02413aa38586c24811237e95937ef18304e108b7e92c890a06793e3bf",
+                "sha256:9c0d415f6b7f2338f93035bba5c0d8c1b464e538bfbb1d598acd47d7969284f0",
+                "sha256:a5167a6403d19c515217b6bcaaa9be420974a6ac30e0da9e84d4fc67a5d474c5",
+                "sha256:ac19c0d68cd42ecd7ead91a3a032fdfff23d29302dbb1311e641a130dfefba97",
+                "sha256:b1e97221cedaf15a54f5243f2c5894bb12ca951ae4ddfd02a9d4ea9df9e1a29d",
+                "sha256:bc2d086fb540d0fa52ce35afaded4ea526b8fc4d3339f783db55c95de40ef02e",
+                "sha256:d1e30ff2d8d58fb2a14961f7aac1bbb1c51f9bdd7da727be35c63826060b0bf3",
+                "sha256:f3b53ba93bb7725acab1e030bc2ecd012a817040fd7851b332f86e2f9bb98dc6"
             ],
-            "version": "==0.2.14"
+            "version": "==0.2.15"
         },
         "pkginfo": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pyAIM <!-- OMIT IN TOC -->
+# pyAIM<!-- omit from toc -->
 
 ![](assets/pyAIM-sm.png)
 
@@ -8,47 +8,46 @@
 
 This project simplifies the interaction between a Python 3 application or script and CyberArk's Application Access Manager's Credential Provider using the appropriate CLIPasswordSDK executable for the Operating System being used.  By simplifying this process, developers are only required to change four (4) lines of code in their Python 3 applications and scripts to securely retrieve privileged secrets from CyberArk's Privileged Access Security (PAS) Core Solution as opposed to thirty or more (30+) without the use of this provided Client Library.
 
-### New in Version 1.2.0: <!-- OMIT IN TOC -->
+### New in Version 1.5.0: <!-- omit from toc -->
 
-Added support for all possible parameters for both AAM Credential Provider (CLIPasswordSDK) and AAM Central Credential Provider (CCPPasswordREST).
+- Added support for `delimiter` parameter in `GetPassword()` method for Credential Provider (CLIPasswordSDK) method.
+- Added support for Client Certificate Authentication in `GetPassword()` method for Centralized Credential Provider (CCPPasswordREST) method.
 
-## Table of Contents <!-- OMIT IN TOC -->
+## Table of Contents <!-- omit from toc -->
 
-- [pyAIM ](#pyaim-)
-    - [New in Version 1.2.0: ](#new-in-version-120-)
-  - [Table of Contents ](#table-of-contents-)
-  - [Install](#install)
-      - [Credential Provider (CLIPasswordSDK) Method](#credential-provider-clipasswordsdk-method)
-      - [Centralized Credential Provider (CCPPasswordREST) Method](#centralized-credential-provider-ccppasswordrest-method)
-    - [Windows](#windows)
-      - [Install Latest Python 3](#install-latest-python-3)
-      - [Install pyAIM via Pip](#install-pyaim-via-pip)
-    - [Linux](#linux)
-      - [Ubuntu/Debian](#ubuntudebian)
-        - [Install Latest Python 3](#install-latest-python-3-1)
-        - [Install pyAIM via Pip](#install-pyaim-via-pip-1)
-      - [RHEL/CentOS](#rhelcentos)
-        - [Install Latest Python 3](#install-latest-python-3-2)
-          - [RHEL](#rhel)
-          - [CentOS](#centos)
-        - [Install pyAIM via Pip](#install-pyaim-via-pip-2)
-    - [MacOS](#macos)
-    - [Z/OS](#zos)
-      - [Install Latest Python 3](#install-latest-python-3-3)
-      - [Install pyAIM via Pip](#install-pyaim-via-pip-3)
-  - [Usage](#usage)
-    - [Check AIMWebService Availability - check\_service()](#check-aimwebservice-availability---check_service)
-      - [Centralized Credential Provider (CCPPasswordREST) Method](#centralized-credential-provider-ccppasswordrest-method-1)
-    - [Retrieve Account - GetPassword()](#retrieve-account---getpassword)
-      - [Credential Provider (CLIPasswordSDK) Method](#credential-provider-clipasswordsdk-method-1)
-        - [Supported Parameters](#supported-parameters)
-        - [Example](#example)
-      - [Centralized Credential Provider (CCPPasswordREST) Method](#centralized-credential-provider-ccppasswordrest-method-2)
-        - [Supported Parameters](#supported-parameters-1)
-        - [Example](#example-1)
-  - [Maintainer](#maintainer)
-  - [Contributing](#contributing)
-  - [License](#license)
+- [Install](#install)
+    - [Credential Provider (CLIPasswordSDK) Method](#credential-provider-clipasswordsdk-method)
+    - [Centralized Credential Provider (CCPPasswordREST) Method](#centralized-credential-provider-ccppasswordrest-method)
+  - [Windows](#windows)
+    - [Install Latest Python 3](#install-latest-python-3)
+    - [Install pyAIM via Pip](#install-pyaim-via-pip)
+  - [Linux](#linux)
+    - [Ubuntu/Debian](#ubuntudebian)
+      - [Install Latest Python 3](#install-latest-python-3-1)
+      - [Install pyAIM via Pip](#install-pyaim-via-pip-1)
+    - [RHEL/CentOS](#rhelcentos)
+      - [Install Latest Python 3](#install-latest-python-3-2)
+        - [RHEL](#rhel)
+        - [CentOS](#centos)
+      - [Install pyAIM via Pip](#install-pyaim-via-pip-2)
+  - [MacOS](#macos)
+  - [Z/OS](#zos)
+    - [Install Latest Python 3](#install-latest-python-3-3)
+    - [Install pyAIM via Pip](#install-pyaim-via-pip-3)
+- [Usage](#usage)
+  - [Check AIMWebService Availability - check\_service()](#check-aimwebservice-availability---check_service)
+    - [Centralized Credential Provider (CCPPasswordREST) Method](#centralized-credential-provider-ccppasswordrest-method-1)
+  - [Retrieve Account - GetPassword()](#retrieve-account---getpassword)
+    - [Credential Provider (CLIPasswordSDK) Method](#credential-provider-clipasswordsdk-method-1)
+      - [Supported Parameters](#supported-parameters)
+      - [Example](#example)
+    - [Centralized Credential Provider (CCPPasswordREST) Method](#centralized-credential-provider-ccppasswordrest-method-2)
+      - [Supported Parameters](#supported-parameters-1)
+      - [Example](#example-1)
+      - [Example with Client Certificate Authentication](#example-with-client-certificate-authentication)
+- [Maintainer](#maintainer)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Install
 
@@ -170,7 +169,7 @@ For compatibility with Dual Accounts where you are referencing a `VirtualUsernam
 from pyaim import CLIPasswordSDK
 
 aimcp = CLIPasswordSDK('/opt/CARKaim/sdk/clipasswordsdk')
-response = aimcp.GetPassword(appid='appID',safe='safeName',object='objectName',output='PassProps.Username,Password')
+response = aimcp.GetPassword(appid='appID',safe='safeName',object='objectName',output='PassProps.Username,Password',delimiter='|')
 
 print('Full Response: {}'.format(response))
 print('Username: {}'.format(response['PassProps.Username']))
@@ -211,6 +210,16 @@ if service_status == 'SUCCESS: AIMWebService Found. Status Code: 200':
     print('Password: {}'.format(response['Content']))
 else:
     raise Exception(service_status)
+```
+
+##### Example with Client Certificate Authentication
+
+```python
+from pyaim import CCPPasswordREST
+
+aimccp = CCPPasswordREST('https://ccp.cyberarkdemo.example', verify=True, cert=('/path/to/cert.pem', '/path/to/key.pem')) # set verify=False to ignore SSL
+
+...
 ```
 
 ## Maintainer

--- a/pyaim/aimccp.py
+++ b/pyaim/aimccp.py
@@ -1,6 +1,5 @@
 import http.client
 import json
-import mimetypes
 import ssl
 import urllib.parse
 
@@ -8,16 +7,21 @@ import urllib.parse
 class CCPPasswordREST(object):
 
     # Runs on Initialization
-    def __init__(self, base_uri, verify=True):
+    def __init__(self, base_uri, verify=True, cert=None):
 
         # Declare Init Variables
         self._base_uri = base_uri.rstrip('/').replace('https://','') # Example: https://pvwa.cyberarkexample.com
-        self._context = ssl.create_default_context()
         self._headers = {'Content-Type': 'application/json'} # Build Header for GET Request
 
-        if verify is False:
+        if verify:
+            self._context = ssl._create_default_context()
+        else:
             self._context = ssl._create_unverified_context()
-            self._context.check_hostname = True
+            self._context.check_hostname = False
+        
+        # Client Certificate Authentication
+        if cert:
+            self._context.load_cert_chain(certfile=cert[0], keyfile=cert[1])
 
 
     # Checks that the AIM Web Service is available


### PR DESCRIPTION
Fixes #62 

Adds support for intializing CCPPasswordREST class with `cert` dict that provides certificate and key for client certificates to be included on the request.  Example added to README.