### PR TITLE
Support for ssl verify location

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -137,7 +137,8 @@ Rocket Software has [ported Python 2 and 3](https://www.rocketsoftware.com/zos-o
 ```python
 from pyaim import CCPPasswordREST
 
-aimccp = CCPPasswordREST('https://ccp.cyberarkdemo.example', verify=True) # set verify=False to ignore SSL
+# set verify=False to ignore SSL or specify a path to a file containing your CAs in pem format
+aimccp = CCPPasswordREST('https://ccp.cyberarkdemo.example', verify=True)
 service_status = aimccp.check_service()
 print(service_status)
 ```
@@ -213,7 +214,7 @@ For compatibility with Dual Accounts where you are referencing a `VirtualUsernam
 ```python
 from pyaim import CCPPasswordREST
 
-# set verify=False to ignore SSL
+# set verify=False to ignore SSL or specify a path to a file containing your CAs in pem format
 aimccp = CCPPasswordREST('https://ccp.cyberarkdemo.example', 'AIMWebService', verify=True, timeout=10)
 
 service_status = aimccp.check_service()
@@ -232,7 +233,7 @@ else:
 ```python
 from pyaim import CCPPasswordREST
 
-# set verify=False to ignore SSL
+# set verify=False to ignore SSL or specify a path to a file containing your CAs in pem format
 aimccp = CCPPasswordREST('https://ccp.cyberarkdemo.example', verify=True, cert=('/path/to/cert.pem', '/path/to/key.pem'))
 
 ...
@@ -243,7 +244,7 @@ aimccp = CCPPasswordREST('https://ccp.cyberarkdemo.example', verify=True, cert=(
 ```python
 from pyaim import CCPPasswordREST
 
-# set verify=False to ignore SSL
+# set verify=False to ignore SSL or specify a path to a file containing your CAs in pem format
 aimccp = CCPPasswordREST('https://ccp.cyberarkdemo.example', 'AIMWebServiceDEV', verify=True)
 
 ...

--- a/pyaim/aimccp.py
+++ b/pyaim/aimccp.py
@@ -17,6 +17,8 @@ class CCPPasswordREST:
 
         if verify:
             self._context = ssl.create_default_context()
+            if verify != True:
+                self._context.load_verify_locations(verify)
         else:
             self._context = ssl._create_unverified_context()
             self._context.check_hostname = False


### PR DESCRIPTION
I have added a couple of lines to CCPPasswordREST to allow the specification of a file containing CAs in PEM format.  I have also updated the README.md.  I am a bit stumped about how to structure a specific test for this since the path will vary according to what the user specifies.  I have tested it on my own system and it works.  The existing test should at least prove I haven't broken anything.

I am not a dev so not at all familiar with how to do this sorry?